### PR TITLE
Fix fullscreen outfit image overlay

### DIFF
--- a/src/components/client/ClientOutfitDetailsModal.tsx
+++ b/src/components/client/ClientOutfitDetailsModal.tsx
@@ -110,6 +110,14 @@ export const ClientOutfitDetailsModal = ({
   const [loading, setLoading] = useState(false);
   const [fullscreenImageOpen, setFullscreenImageOpen] = useState(false);
 
+  const handleModalOpenChange = (newOpen: boolean) => {
+    if (!newOpen && fullscreenImageOpen) {
+      setFullscreenImageOpen(false)
+      return
+    }
+    onOpenChange(newOpen)
+  }
+
   useEffect(() => {
     if (outfit) {
       fetchOutfitClothingItems();
@@ -216,7 +224,7 @@ export const ClientOutfitDetailsModal = ({
 
   return (
     <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
+      <Dialog open={open} onOpenChange={handleModalOpenChange}>
         <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Détails de la tenue</DialogTitle>
@@ -290,7 +298,7 @@ export const ClientOutfitDetailsModal = ({
             <div className="flex justify-end pt-4">
               <Button
                 variant="outline"
-                onClick={() => onOpenChange(false)}
+                onClick={() => handleModalOpenChange(false)}
               >
                 Fermer
               </Button>

--- a/src/components/client/ClientOutfitDetailsModal.tsx
+++ b/src/components/client/ClientOutfitDetailsModal.tsx
@@ -1,5 +1,6 @@
 
 import { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -54,26 +55,33 @@ const seasonTranslations: { [key: string]: string } = {
   winter: "Hiver"
 };
 
-const FullscreenImageModal = ({ 
-  open, 
-  onOpenChange, 
-  imageUrl, 
-  alt 
-}: { 
-  open: boolean; 
-  onOpenChange: (open: boolean) => void; 
-  imageUrl: string; 
-  alt: string; 
+const FullscreenImageModal = ({
+  open,
+  onOpenChange,
+  imageUrl,
+  alt
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  imageUrl: string;
+  alt: string;
 }) => {
   if (!open) return null;
 
-  return (
-    <div 
-      className="fixed inset-0 bg-black bg-opacity-90 flex items-center justify-center z-50"
-      onClick={() => onOpenChange(false)}
+  return createPortal(
+    <div
+      className="fixed inset-0 m-0 p-0 bg-black bg-opacity-90 flex items-center justify-center z-[10000]"
+      onPointerDownCapture={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation()
+        onOpenChange(false)
+      }}
     >
       <button
-        onClick={() => onOpenChange(false)}
+        onClick={(e) => {
+          e.stopPropagation()
+          onOpenChange(false)
+        }}
         className="absolute top-4 right-4 text-white hover:text-gray-300 transition-colors"
       >
         <X className="h-8 w-8" />
@@ -84,7 +92,8 @@ const FullscreenImageModal = ({
         className="max-w-full max-h-full object-contain"
         onClick={(e) => e.stopPropagation()}
       />
-    </div>
+    </div>,
+    document.body
   );
 };
 
@@ -239,11 +248,11 @@ export const ClientOutfitDetailsModal = ({
 
             {/* Outfit Image */}
             <div className="flex justify-center">
-              <div className="w-64 h-64 border rounded-md overflow-hidden bg-gray-50 cursor-pointer" onClick={() => setFullscreenImageOpen(true)}>
+              <div className="w-64 h-64 border rounded-md overflow-hidden bg-gray-50 cursor-zoom-in" onClick={() => setFullscreenImageOpen(true)}>
                 <img
                   src={optimizedOutfitImageUrl}
                   alt={outfit.name}
-                  className="w-full h-full object-contain hover:opacity-90 transition-opacity"
+                  className="w-full h-full object-contain hover:opacity-90 transition-opacity cursor-zoom-in"
                 />
               </div>
             </div>
@@ -251,7 +260,6 @@ export const ClientOutfitDetailsModal = ({
             {/* Comments */}
             {outfit.comments && (
               <div className="mt-4 p-3 bg-bibabop-lightgrey rounded-md">
-                <p className="text-sm font-medium mb-1">Commentaires du conseiller en image:</p>
                 <p className="text-sm">{outfit.comments}</p>
               </div>
             )}

--- a/src/components/consultant/EditOutfitModal.tsx
+++ b/src/components/consultant/EditOutfitModal.tsx
@@ -67,8 +67,8 @@ const FullscreenImageModal = ({
   if (!open) return null;
 
   return (
-    <div 
-      className="fixed inset-0 bg-black bg-opacity-90 flex items-center justify-center z-50"
+    <div
+      className="fixed inset-0 m-0 p-0 bg-black bg-opacity-90 flex items-center justify-center z-[60]"
       onClick={() => onOpenChange(false)}
     >
       <button
@@ -227,11 +227,14 @@ export const EditOutfitModal = ({ open, onOpenChange, outfit, onSave }: EditOutf
           <div className="space-y-6">
             {/* Outfit Image */}
             <div className="flex justify-center">
-              <div className="w-64 h-64 border rounded-md overflow-hidden bg-gray-50 cursor-pointer" onClick={() => setFullscreenImageOpen(true)}>
+              <div
+                className="w-64 h-64 border rounded-md overflow-hidden bg-gray-50 cursor-zoom-in"
+                onClick={() => setFullscreenImageOpen(true)}
+              >
                 <img
                   src={optimizedOutfitImageUrl}
                   alt={outfit.name}
-                  className="w-full h-full object-contain hover:opacity-90 transition-opacity"
+                  className="w-full h-full object-contain hover:opacity-90 transition-opacity cursor-zoom-in"
                 />
               </div>
             </div>

--- a/src/components/consultant/EditOutfitModal.tsx
+++ b/src/components/consultant/EditOutfitModal.tsx
@@ -106,6 +106,14 @@ export const EditOutfitModal = ({ open, onOpenChange, outfit, onSave }: EditOutf
   const [isSaving, setIsSaving] = useState(false);
   const [fullscreenImageOpen, setFullscreenImageOpen] = useState(false);
 
+  const handleModalOpenChange = (newOpen: boolean) => {
+    if (!newOpen && fullscreenImageOpen) {
+      setFullscreenImageOpen(false)
+      return
+    }
+    onOpenChange(newOpen)
+  }
+
   useEffect(() => {
     if (outfit) {
       setName(outfit.name);
@@ -227,7 +235,7 @@ export const EditOutfitModal = ({ open, onOpenChange, outfit, onSave }: EditOutf
 
   return (
     <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
+      <Dialog open={open} onOpenChange={handleModalOpenChange}>
         <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Modifier la tenue</DialogTitle>

--- a/src/components/consultant/EditOutfitModal.tsx
+++ b/src/components/consultant/EditOutfitModal.tsx
@@ -1,5 +1,6 @@
 
 import { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -53,11 +54,11 @@ const seasonTranslations: { [key: string]: string } = {
   winter: "Hiver"
 };
 
-const FullscreenImageModal = ({ 
-  open, 
-  onOpenChange, 
-  imageUrl, 
-  alt 
+const FullscreenImageModal = ({
+  open,
+  onOpenChange,
+  imageUrl,
+  alt
 }: { 
   open: boolean; 
   onOpenChange: (open: boolean) => void; 
@@ -66,17 +67,20 @@ const FullscreenImageModal = ({
 }) => {
   if (!open) return null;
 
-  return (
+  return createPortal(
     <div
-      className="fixed inset-0 m-0 p-0 bg-black bg-opacity-90 flex items-center justify-center z-[9999]"
-      onPointerDown={(e) => e.stopPropagation()}
+      className="fixed inset-0 m-0 p-0 bg-black bg-opacity-90 flex items-center justify-center z-[10000]"
+      onPointerDownCapture={(e) => e.stopPropagation()}
       onClick={(e) => {
         e.stopPropagation()
         onOpenChange(false)
       }}
     >
       <button
-        onClick={() => onOpenChange(false)}
+        onClick={(e) => {
+          e.stopPropagation()
+          onOpenChange(false)
+        }}
         className="absolute top-4 right-4 text-white hover:text-gray-300 transition-colors"
       >
         <X className="h-8 w-8" />
@@ -87,7 +91,8 @@ const FullscreenImageModal = ({
         className="max-w-full max-h-full object-contain"
         onClick={(e) => e.stopPropagation()}
       />
-    </div>
+    </div>,
+    document.body
   );
 };
 

--- a/src/components/consultant/EditOutfitModal.tsx
+++ b/src/components/consultant/EditOutfitModal.tsx
@@ -68,8 +68,12 @@ const FullscreenImageModal = ({
 
   return (
     <div
-      className="fixed inset-0 m-0 p-0 bg-black bg-opacity-90 flex items-center justify-center z-[60]"
-      onClick={() => onOpenChange(false)}
+      className="fixed inset-0 m-0 p-0 bg-black bg-opacity-90 flex items-center justify-center z-[9999]"
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation()
+        onOpenChange(false)
+      }}
     >
       <button
         onClick={() => onOpenChange(false)}

--- a/src/pages/client/ClientOutfits.tsx
+++ b/src/pages/client/ClientOutfits.tsx
@@ -138,11 +138,11 @@ export default function ClientOutfits() {
                       </CardDescription>
                     </CardHeader>
                     <CardContent>
-                      <div className="aspect-auto bg-muted rounded-md flex items-center justify-center mb-4 overflow-hidden">
+                      <div className="mb-4 rounded-md overflow-hidden bg-muted">
                         <img
                           src={optimizedImageUrl}
                           alt={outfit.name}
-                          className="w-full h-auto object-contain max-h-[200px]"
+                          className="w-full h-48 object-cover"
                         />
                       </div>
                       {outfit.comments && (

--- a/src/pages/client/ClientOutfits.tsx
+++ b/src/pages/client/ClientOutfits.tsx
@@ -138,11 +138,11 @@ export default function ClientOutfits() {
                       </CardDescription>
                     </CardHeader>
                     <CardContent>
-                      <div className="mb-4 rounded-md overflow-hidden bg-muted">
+                      <div className="mb-4 rounded-md overflow-hidden bg-muted flex items-center justify-center h-48">
                         <img
                           src={optimizedImageUrl}
                           alt={outfit.name}
-                          className="w-full h-48 object-cover"
+                          className="w-full max-h-full object-contain"
                         />
                       </div>
                       {outfit.comments && (

--- a/src/pages/client/ClientOutfits.tsx
+++ b/src/pages/client/ClientOutfits.tsx
@@ -5,7 +5,6 @@ import { Input } from "@/components/ui/input";
 import { Search } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import { useOutfits } from "@/hooks/useOutfits";
 import { getOptimizedImageUrl } from "@/utils/imageUtils";
 import { ClientOutfitDetailsModal } from "@/components/client/ClientOutfitDetailsModal";
 import { format } from "date-fns";
@@ -128,7 +127,7 @@ export default function ClientOutfits() {
             <div className="grid md:grid-cols-3 gap-6">
               {filteredOutfits.map((outfit) => {
                 const optimizedImageUrl = getOptimizedImageUrl(outfit.image_url, 400);
-                
+
                 return (
                   <Card key={outfit.id} className="card-hover">
                     <CardHeader>
@@ -138,22 +137,17 @@ export default function ClientOutfits() {
                       </CardDescription>
                     </CardHeader>
                     <CardContent>
-                      <div className="mb-4 rounded-md overflow-hidden bg-muted flex items-center justify-center h-48">
+                      <div className="mb-4 rounded-md overflow-hidden bg-muted">
                         <img
                           src={optimizedImageUrl}
                           alt={outfit.name}
-                          className="w-full max-h-full object-contain"
+                          className="w-full object-cover"
                         />
                       </div>
-                      {outfit.comments && (
-                        <div className="mt-4 p-3 bg-bibabop-lightgrey rounded-md">
-                          <p className="text-sm">{outfit.comments}</p>
-                        </div>
-                      )}
                     </CardContent>
                     <CardFooter>
-                      <Button 
-                        variant="outline" 
+                      <Button
+                        variant="outline"
                         className="w-full"
                         onClick={() => handleViewDetails(outfit)}
                       >

--- a/src/pages/client/ClientOutfits.tsx
+++ b/src/pages/client/ClientOutfits.tsx
@@ -125,7 +125,7 @@ export default function ClientOutfits() {
               </p>
             </div>
           ) : (
-            <div className="grid md:grid-cols-2 gap-6">
+            <div className="grid md:grid-cols-3 gap-6">
               {filteredOutfits.map((outfit) => {
                 const optimizedImageUrl = getOptimizedImageUrl(outfit.image_url, 400);
                 
@@ -147,7 +147,6 @@ export default function ClientOutfits() {
                       </div>
                       {outfit.comments && (
                         <div className="mt-4 p-3 bg-bibabop-lightgrey rounded-md">
-                          <p className="text-sm font-medium mb-1">Commentaires du conseiller en image:</p>
                           <p className="text-sm">{outfit.comments}</p>
                         </div>
                       )}


### PR DESCRIPTION
## Summary
- show zoom-in cursor when hovering outfit image
- ensure fullscreen image overlay appears above dialog and sticks to edges

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863e04f0dc48320b5e33c5f847db22f