### PR TITLE
Enable JPEG screenshot saving

### DIFF
--- a/src/hooks/useOutfits.ts
+++ b/src/hooks/useOutfits.ts
@@ -48,11 +48,11 @@ export const useOutfits = () => {
 
     try {
       // Upload image to storage
-      const fileName = `${user.id}/${Date.now()}-outfit.png`;
+      const fileName = `${user.id}/${Date.now()}-outfit.jpg`;
       const { data: uploadData, error: uploadError } = await supabase.storage
         .from('outfit-images')
         .upload(fileName, imageBlob, {
-          contentType: 'image/png',
+          contentType: 'image/jpeg',
         });
 
       if (uploadError) throw uploadError;

--- a/src/pages/consultant/OutfitCreator.tsx
+++ b/src/pages/consultant/OutfitCreator.tsx
@@ -375,8 +375,11 @@ const OutfitCreator = () => {
       // Wait a brief moment for the UI to update
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // Capture screenshot of the canvas
-      const imageBlob = await captureElementAsImage(canvasRef.current);
+      // Capture screenshot of the canvas in JPEG format
+      const imageBlob = await captureElementAsImage(
+        canvasRef.current,
+        'image/jpeg'
+      );
       
       // Get clothing item IDs
       const clothingItemIds = placedItems.map(item => item.id);

--- a/src/utils/screenshotUtils.ts
+++ b/src/utils/screenshotUtils.ts
@@ -1,7 +1,10 @@
 
 import html2canvas from 'html2canvas';
 
-export const captureElementAsImage = async (element: HTMLElement): Promise<Blob> => {
+export const captureElementAsImage = async (
+  element: HTMLElement,
+  format: 'image/png' | 'image/jpeg' = 'image/png'
+): Promise<Blob> => {
   try {
     const canvas = await html2canvas(element, {
       backgroundColor: '#e5e7eb', // gray-200 background
@@ -13,9 +16,13 @@ export const captureElementAsImage = async (element: HTMLElement): Promise<Blob>
     });
 
     return new Promise((resolve) => {
-      canvas.toBlob((blob) => {
-        resolve(blob!);
-      }, 'image/png', 0.9);
+      canvas.toBlob(
+        (blob) => {
+          resolve(blob!);
+        },
+        format,
+        format === 'image/jpeg' ? 0.8 : 0.9
+      );
     });
   } catch (error) {
     console.error('Error capturing screenshot:', error);


### PR DESCRIPTION
## Summary
- support custom formats when capturing the outfit canvas
- save outfit screenshots as JPEG

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865261fdb688320ac3e06e5447c9d0e