### PR TITLE
Fix messenger layout and unread count

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./contexts/AuthContext";
 import { UserProfileProvider } from "./contexts/UserProfileContext";
+import { MessagesProvider } from "./hooks/useMessages";
 import { ProtectedRoute } from "./components/auth/ProtectedRoute";
 import LandingPage from "./pages/LandingPage";
 import Login from "./pages/auth/Login";
@@ -47,10 +48,11 @@ const App = () => {
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
         <UserProfileProvider>
-          <TooltipProvider>
-            <Toaster />
-            <Sonner />
-            <BrowserRouter>
+          <MessagesProvider>
+            <TooltipProvider>
+              <Toaster />
+              <Sonner />
+              <BrowserRouter>
               <Routes>
                 <Route path="/" element={<LandingPage />} />
                 <Route path="/login" element={<Login />} />
@@ -119,6 +121,7 @@ const App = () => {
               </Routes>
             </BrowserRouter>
           </TooltipProvider>
+        </MessagesProvider>
         </UserProfileProvider>
       </AuthProvider>
     </QueryClientProvider>

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,5 +1,5 @@
 
-import { useState, useEffect, useCallback } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUserProfile } from '@/contexts/UserProfileContext';
 import { supabase } from '@/integrations/supabase/client';
@@ -28,7 +28,28 @@ export interface Conversation {
   unread_count: number;
 }
 
+interface MessagesContextType {
+  conversations: Conversation[];
+  messages: Message[];
+  loading: boolean;
+  fetchConversations: () => Promise<void>;
+  fetchMessages: (conversationId: string) => Promise<void>;
+  sendMessage: (conversationId: string, content: string) => Promise<void>;
+  createConversation: (otherUserId: string) => Promise<string | null>;
+  getTotalUnreadCount: () => number;
+}
+
+const MessagesContext = createContext<MessagesContextType | undefined>(undefined);
+
 export const useMessages = () => {
+  const context = useContext(MessagesContext);
+  if (!context) {
+    throw new Error('useMessages must be used within a MessagesProvider');
+  }
+  return context;
+};
+
+const useProvideMessages = () => {
   const { user } = useAuth();
   const { profile } = useUserProfile();
   const { toast } = useToast();
@@ -351,4 +372,11 @@ export const useMessages = () => {
     createConversation,
     getTotalUnreadCount
   };
+};
+
+export const MessagesProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const value = useProvideMessages();
+  return (
+    <MessagesContext.Provider value={value}>{children}</MessagesContext.Provider>
+  );
 };

--- a/src/pages/shared/Conversation.tsx
+++ b/src/pages/shared/Conversation.tsx
@@ -55,11 +55,14 @@ export default function Conversation() {
   }, [conversationId, fetchMessages]);
 
   useEffect(() => {
-    console.log('📜 Auto-scroll useEffect triggered, messages count:', messages.length);
+    console.log('📜 Auto-scroll useEffect triggered', {
+      conversationId,
+      messagesCount: messages.length
+    });
     if (messagesEndRef.current) {
       messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [messages.length]);
+  }, [conversationId, messages.length]);
 
   const handleSendMessage = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -146,7 +149,7 @@ export default function Conversation() {
   console.log('🎨 Rendering conversation with', messageGroups.length, 'message groups');
 
   return (
-    <div className="h-screen flex flex-col p-6">
+    <div className="h-screen box-border flex flex-col p-6">
       <Card className="flex-1 flex flex-col min-h-0">
         <CardHeader className="border-b flex-shrink-0">
           <div className="flex items-center space-x-4">


### PR DESCRIPTION
## Summary
- add `box-border` to keep conversation height within screen
- scroll conversations to the bottom when opening
- share messages through new `MessagesProvider` context
- wrap app with `MessagesProvider`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f28943608320a36714f70b6470a7